### PR TITLE
Fix error `Error: Cannot find module 'lodash.camelCase' ` on linux

### DIFF
--- a/rules/v-el-and-v-ref.js
+++ b/rules/v-el-and-v-ref.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var chalk = require('chalk')
-var camelCase = require('lodash.camelCase')
+var camelCase = require('lodash.camelcase')
 
 module.exports = {
   pattern: /\b(v-el|v-ref):([\w-]+)/,


### PR DESCRIPTION
Fixes this error on linux (any maybe on other systems):

```
> node index.js 
module.js:457
    throw err;
    ^

Error: Cannot find module 'lodash.camelCase'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/maks/Стільниця/vue-migration-helper/rules/v-el-and-v-ref.js:4:17)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
```
